### PR TITLE
azurerm_redis_cache: skip listKeys when access-key auth is disabled

### DIFF
--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -706,9 +706,22 @@ func resourceRedisCacheRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	keysResp, err := client.RedisListKeys(ctx, *id)
-	if err != nil {
-		return fmt.Errorf("listing keys for %s: %+v", *id, err)
+	// Access keys can only be listed when access-key authentication is
+	// enabled. When it is disabled (Entra-ID-only), RedisListKeys fails and
+	// the Read returns an error, which wedges the reconcile loop: the
+	// resource never settles, so every reconcile re-issues an Update. Read
+	// the toggle off the model and skip the call when it is disabled.
+	accessKeysAuthenticationEnabled := true
+	if resp.Model != nil && resp.Model.Properties.DisableAccessKeyAuthentication != nil {
+		accessKeysAuthenticationEnabled = !*resp.Model.Properties.DisableAccessKeyAuthentication
+	}
+
+	var keysResp redisresources.RedisListKeysOperationResponse
+	if accessKeysAuthenticationEnabled {
+		keysResp, err = client.RedisListKeys(ctx, *id)
+		if err != nil {
+			return fmt.Errorf("listing keys for %s: %+v", *id, err)
+		}
 	}
 
 	patchSchedulesRedisId := redispatchschedules.NewRediID(id.SubscriptionId, id.ResourceGroupName, id.RedisName)
@@ -786,10 +799,21 @@ func resourceRedisCacheRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			return fmt.Errorf("setting `redis_configuration`: %+v", err)
 		}
 
-		d.Set("primary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keysResp.Model.PrimaryKey, true))
-		d.Set("secondary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keysResp.Model.SecondaryKey, true))
-		d.Set("primary_access_key", keysResp.Model.PrimaryKey)
-		d.Set("secondary_access_key", keysResp.Model.SecondaryKey)
+		if accessKeysAuthenticationEnabled && keysResp.Model != nil {
+			d.Set("primary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keysResp.Model.PrimaryKey, true))
+			d.Set("secondary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keysResp.Model.SecondaryKey, true))
+			d.Set("primary_access_key", keysResp.Model.PrimaryKey)
+			d.Set("secondary_access_key", keysResp.Model.SecondaryKey)
+		} else {
+			// Access-key auth is disabled, so the keys are not retrievable
+			// (Azure rejects listKeys). Clear any secrets that were carried
+			// over in state from when it was enabled (true -> false switch),
+			// rather than leaving stale values behind.
+			d.Set("primary_connection_string", "")
+			d.Set("secondary_connection_string", "")
+			d.Set("primary_access_key", "")
+			d.Set("secondary_access_key", "")
+		}
 		d.Set("access_keys_authentication_enabled", !pointer.From(props.DisableAccessKeyAuthentication))
 
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {


### PR DESCRIPTION
## Problem

`resourceRedisCacheRead` calls `client.RedisListKeys` unconditionally. When a cache has `access_keys_authentication_enabled = false` (Entra-ID-only), Azure refuses the `listKeys` action, so `Read` returns:

```
listing keys for <id>: ...
```

Under Crossplane/upjet this failed `Read` is treated as an unsettled resource, so the controller re-issues an `Update` on every reconcile — a perpetual update loop (~22 Azure update calls/min observed), with each async callback racing the observe-status write (`the object has been modified`).

## Root cause

The `access_keys_authentication_enabled` toggle was added in #27039 on top of a pre-existing unconditional `RedisListKeys` call, without guarding it. The provider already has `DisableAccessKeyAuthentication` from the `RedisGet` response, so it knows keys are off before it asks for them.

## Fix

Guard the `listKeys` call on the toggle: only list keys when key auth is enabled. On the disabled path, clear `primary_access_key`, `secondary_access_key` and the connection strings so secrets carried over from a `true -> false` switch are not left stale in state — the same treatment applied to cognitive accounts in #27851.

## Relation to #31991

This is the deterministic, config-driven counterpart to the permission-based case in #31991 (caller lacks `Microsoft.Cache/redis/listKeys/action`). This change does not call `listKeys` at all when key auth is disabled; the permission case still needs a separate graceful-degrade-on-error branch.

## Testing

`go build` and `go vet` on `./internal/services/redis/` pass.