### PR TITLE
Expose a method to append response middleware to AzureRM clients

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -22,6 +22,7 @@ import (
 	storagecache_2024_07_01 "github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2024-07-01"
 	systemcentervirtualmachinemanager_2023_10_07 "github.com/hashicorp/go-azure-sdk/resource-manager/systemcentervirtualmachinemanager/2023-10-07"
 	workloads_v2024_09_01 "github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01"
+	sdkclient "github.com/hashicorp/go-azure-sdk/sdk/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	aadb2c "github.com/hashicorp/terraform-provider-azurerm/internal/services/aadb2c/client"
@@ -286,6 +287,10 @@ type Client struct {
 	VoiceServices                     *voiceServices.Client
 	Web                               *web.Client
 	Workloads                         *workloads_v2024_09_01.Client
+
+	// armClients holds every client.BaseClient registered during Build.
+	// Populated once by Build(); read by AppendResponseMiddleware.
+	armClients []sdkclient.BaseClient
 }
 
 // NOTE: it should be possible for this method to become Private once the top level Client's removed
@@ -681,5 +686,14 @@ func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error 
 		return fmt.Errorf("building clients for Workloads: %+v", err)
 	}
 
+	client.armClients = o.ConfiguredClients()
 	return nil
+}
+
+// AppendResponseMiddleware registers mw with every go-azure-sdk client
+// that was configured during provider initialisation.
+func (c *Client) AppendResponseMiddleware(mw sdkclient.ResponseMiddleware) {
+	for _, ac := range c.armClients {
+		ac.AppendResponseMiddleware(mw)
+	}
 }

--- a/internal/common/client_options.go
+++ b/internal/common/client_options.go
@@ -59,10 +59,14 @@ type ClientOptions struct {
 
 	// TODO: Remove when all go-autorest clients are gone
 	SkipProviderReg bool
+
+	// configuredClients accumulates every client.BaseClient passed to Configure.
+	// Read once by Client.Build() after all service clients are constructed.
+	configuredClients []client.BaseClient
 }
 
 // Configure set up a resourcemanager.Client using an auth.Authorizer from hashicorp/go-azure-sdk
-func (o ClientOptions) Configure(c client.BaseClient, authorizer auth.Authorizer) {
+func (o *ClientOptions) Configure(c client.BaseClient, authorizer auth.Authorizer) {
 	c.SetAuthorizer(authorizer)
 	c.SetUserAgent(userAgent(c.GetUserAgent(), o.TerraformVersion, o.PartnerId, o.DisableTerraformPartnerID))
 
@@ -76,6 +80,13 @@ func (o ClientOptions) Configure(c client.BaseClient, authorizer auth.Authorizer
 
 	c.AppendRequestMiddleware(requestLoggerMiddleware("AzureRM"))
 	c.AppendResponseMiddleware(responseLoggerMiddleware("AzureRM"))
+	o.configuredClients = append(o.configuredClients, c)
+}
+
+// ConfiguredClients returns all client.BaseClient instances passed to Configure.
+// Intended to be called once by Client.Build() after all service NewClient calls complete.
+func (o *ClientOptions) ConfiguredClients() []client.BaseClient {
+	return o.configuredClients
 }
 
 // ConfigureClient sets up an autorest.Client using an autorest.Authorizer

--- a/xpprovider/xpprovider.go
+++ b/xpprovider/xpprovider.go
@@ -2,6 +2,8 @@ package xpprovider
 
 import (
 	"context"
+
+	sdkclient "github.com/hashicorp/go-azure-sdk/sdk/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider"
@@ -15,4 +17,16 @@ func GetProviderSchema(_ context.Context) (*schema.Provider, error) {
 
 func (b *AzureClientBuilder) GetClient(ctx context.Context) (*clients.Client, error) {
 	return clients.Build(ctx, (clients.ClientBuilder)(*b))
+}
+
+// RegisterResponseMiddleware appends mw to every go-azure-sdk client held by
+// meta (the value returned by schema.Provider.Meta()). It returns false when
+// meta is not a *clients.Client.
+func RegisterResponseMiddleware(meta any, mw sdkclient.ResponseMiddleware) bool {
+	c, ok := meta.(*clients.Client)
+	if !ok {
+		return false
+	}
+	c.AppendResponseMiddleware(mw)
+	return true
 }


### PR DESCRIPTION
### Description of your changes
Exposes middleware registration for the AzureRM clients, which allows to configure collection of `upjet_resource_external_api_calls_total` metric

Fixes #

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
~~- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~~

### How has this code been tested
Tested with local branch of provider-upjet-azure, example metric:

```shell
judasz@Jonaszs-MacBook-Pro provider-upjet-azure % curl localhost:8080/metrics | rg "upjet_resource_external_api_calls_total"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0# HELP upjet_resource_external_api_calls_total The number of external API calls.
# TYPE upjet_resource_external_api_calls_total counter
upjet_resource_external_api_calls_total{operation="DELETE",service="Microsoft.Network"} 1
upjet_resource_external_api_calls_total{operation="GET",service="Microsoft.Network"} 3
100 2124k    0 2124k    0     0   117M      0 --:--:-- --:--:-- --:--:--  122M
```

